### PR TITLE
Fix plugin init

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
 script:
   - git clone https://github.com/ElementsProject/lightning.git
   - cd lightning
-  - git checkout v0.9.2
+  - git checkout v0.9.3
   - python3 -m virtualenv venv
   - source venv/bin/activate
   - pip install -r requirements.txt

--- a/Makefile.patch
+++ b/Makefile.patch
@@ -1,5 +1,5 @@
 diff --git a/plugins/Makefile b/plugins/Makefile
-index fd7b05c13..9e3dbf5cf 100644
+index cbaf5b35c..2bcce7407 100644
 --- a/plugins/Makefile
 +++ b/plugins/Makefile
 @@ -13,6 +13,9 @@ PLUGIN_BCLI_OBJS := $(PLUGIN_BCLI_SRC:.c=.o)
@@ -12,8 +12,8 @@ index fd7b05c13..9e3dbf5cf 100644
  PLUGIN_LIB_SRC := plugins/libplugin.c
  PLUGIN_LIB_HEADER := plugins/libplugin.h
  PLUGIN_LIB_OBJS := $(PLUGIN_LIB_SRC:.c=.o)
-@@ -54,7 +57,8 @@ PLUGINS :=					\
- 	plugins/keysend				\
+@@ -70,7 +73,8 @@ PLUGINS :=					\
+ 	plugins/offers				\
  	plugins/pay				\
  	plugins/txprepare			\
 -	plugins/spenderp
@@ -22,9 +22,9 @@ index fd7b05c13..9e3dbf5cf 100644
  
  # Make sure these depend on everything.
  ALL_C_SOURCES += $(PLUGIN_ALL_SRC)
-@@ -116,6 +120,8 @@ $(PLUGIN_KEYSEND_OBJS): $(PLUGIN_PAY_LIB_HEADER)
+@@ -136,6 +140,8 @@ plugins/offers: bitcoin/chainparams.o $(PLUGIN_OFFERS_OBJS) $(PLUGIN_LIB_OBJS) $
  
- plugins/spenderp: bitcoin/chainparams.o $(PLUGIN_SPENDER_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS)
+ plugins/fetchinvoice: bitcoin/chainparams.o $(PLUGIN_FETCHINVOICE_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) common/bolt12.o common/bolt12_merkle.o common/iso4217.o $(WIRE_OBJS) bitcoin/block.o common/channel_id.o bitcoin/preimage.o $(JSMN_OBJS) $(CCAN_OBJS) common/gossmap.o common/dijkstra.o common/route.o common/blindedpath.o common/hmac.o common/blinding.o
  
 +plugins/esplora: bitcoin/chainparams.o $(PLUGIN_ESPLORA_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS)
 +

--- a/esplora.c
+++ b/esplora.c
@@ -671,7 +671,7 @@ static bool configure_esplora_with_network(const char *network,
 	return false;
 }
 
-static void init(struct plugin *p, const char *buffer, const jsmntok_t *config)
+static const char *init(struct plugin *p, const char *buffer, const jsmntok_t *config)
 {
 	const jsmntok_t *proxy_tok = json_get_member(buffer, config, "proxy");
 	if (proxy_tok) {
@@ -719,6 +719,7 @@ static void init(struct plugin *p, const char *buffer, const jsmntok_t *config)
 	if (proxy_conf->proxy_enabled && !esplora->proxy_disabled)
 		plugin_log(p, LOG_INFORM, "proxy configuration %s:%d",
 			   proxy_conf->address, proxy_conf->port);
+	return NULL;
 }
 
 static struct esplora *new_esplora(const tal_t *ctx)


### PR DESCRIPTION
Without this fix esplora plugin was uncompilable (see [related comment in the moving-PR](https://github.com/jsarenik/lightning/pull/1#issuecomment-771928660)).

This PR contains also an updated Makefile patch, just to keep in sync with the changes (again, comes from above-mentioned PR).