### PR TITLE
pass ldflags inside plugins Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,6 @@ jobs:
           pip install -r requirements.txt
           cp ../esplora.* plugins/
           patch -p1 < ../Makefile.patch
-          sed -i 's/PLUGINS=/PLUGINS=plugins\/esplora /g' Makefile
-          sed -i 's/LDLIBS = /LDLIBS = -lcurl -lssl -lcrypto /g' Makefile
           ./configure
           make
           deactivate

--- a/Makefile.patch
+++ b/Makefile.patch
@@ -26,7 +26,7 @@ index cbaf5b35c..2bcce7407 100644
  
  plugins/fetchinvoice: bitcoin/chainparams.o $(PLUGIN_FETCHINVOICE_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) common/bolt12.o common/bolt12_merkle.o common/iso4217.o $(WIRE_OBJS) bitcoin/block.o common/channel_id.o bitcoin/preimage.o $(JSMN_OBJS) $(CCAN_OBJS) common/gossmap.o common/dijkstra.o common/route.o common/blindedpath.o common/hmac.o common/blinding.o
  
-+plugins/esplora: bitcoin/chainparams.o $(PLUGIN_ESPLORA_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS)
++plugins/esplora: bitcoin/chainparams.o $(PLUGIN_ESPLORA_OBJS) $(PLUGIN_LIB_OBJS) $(PLUGIN_COMMON_OBJS) $(JSMN_OBJS) $(CCAN_OBJS) -lcurl -lssl -lcrypto
 +
  $(PLUGIN_ALL_OBJS): $(PLUGIN_LIB_HEADER)
  

--- a/apply.sh
+++ b/apply.sh
@@ -9,4 +9,4 @@ test "$1" = "" || { test -d $1; cd $1; }
 
 cp $EDIR/esplora.c plugins
 patch -p1 < $EDIR/Makefile.patch
-sed -i 's/LDLIBS = /LDLIBS = -lcurl -lssl -lcrypto /g' Makefile
+#sed -i 's/LDLIBS = /LDLIBS = -lcurl -lssl -lcrypto /g' Makefile


### PR DESCRIPTION
Remove sed replace of lightning Makefile in order to pass LDFLAGS with external library during the esplora plugin compilation